### PR TITLE
Return the error as String rather than Exception

### DIFF
--- a/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
+++ b/android/src/main/java/com/it_nomads/fluttersecurestorage/FlutterSecureStoragePlugin.java
@@ -11,6 +11,8 @@ import android.util.Log;
 import com.it_nomads.fluttersecurestorage.ciphers.StorageCipher;
 import com.it_nomads.fluttersecurestorage.ciphers.StorageCipher18Implementation;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
@@ -212,7 +214,9 @@ public class FlutterSecureStoragePlugin implements MethodCallHandler, FlutterPlu
                 }
 
             } catch (Exception e) {
-                result.error("Exception encountered", call.method, e);
+                StringWriter stringWriter = new StringWriter();
+                e.printStackTrace(new PrintWriter(stringWriter));
+                result.error("Exception encountered", call.method, stringWriter.toString());
             }
         }
     }


### PR DESCRIPTION
StandardMessageCodec does not accept Exception values and, therefore, will throw an IllegalArgumentException.

https://github.com/flutter/engine/blob/7f388bf814d302f54379f8528ad2366aa03d5e28/shell/platform/android/io/flutter/plugin/common/StandardMessageCodec.java#L208-L280